### PR TITLE
Fix Safari profile windows not opening reliably

### DIFF
--- a/src/new_window.js
+++ b/src/new_window.js
@@ -11,15 +11,23 @@
 // ./new_window.js x3               -> Opens 3 new windows.
 // ./new_window.js p2               -> Opens 1 new window in profile 2.
 
+ObjC.import("stdlib");
+
+function getConfiguredProfileName(profile) {
+	const value = $.getenv(`profile${profile}`);
+	return value ? value.toString().trim() : "";
+}
+
 /**
  * Parses script arguments to determine window count, profile, or URL.
  * @param {string[]} argv - The script arguments.
- * @returns {{windowCount: number, profile: string|null, url: string|null}}
+ * @returns {{windowCount: number, profile: string|null, profileName: string|null, url: string|null}}
  */
 function parseArgs(argv) {
 	const config = {
 		windowCount: 1,
 		profile: null,
+		profileName: null,
 		url: null,
 	};
 
@@ -36,6 +44,7 @@ function parseArgs(argv) {
 	} else if (/^p[1-5]$/.test(firstArg)) {
 		// Parse profile (e.g., "p2")
 		config.profile = firstArg.substring(1);
+		config.profileName = getConfiguredProfileName(config.profile);
 	} else {
 		// The rest is the URL
 		const rawUrl = argv.join(" ");
@@ -61,7 +70,7 @@ function run(argv) {
 	Safari.includeStandardAdditions = true;
 
 	// --- Argument Parsing ---
-	const { windowCount, profile, url } = parseArgs(argv);
+	const { windowCount, profile, profileName, url } = parseArgs(argv);
 
 	// --- Safari Automation ---
 
@@ -73,15 +82,75 @@ function run(argv) {
 		delay(0.5);
 	} else {
 		Safari.activate();
+		delay(0.3);
 	}
 
-	const openInProfile = (p) => {
-		// Use keyboard shortcut to switch to the selected profile
-		// Option + Shift + Command + n
+	const clickProfileMenuItem = (name) => {
+		const normalize = (value) => (value || "").toLowerCase().trim();
+		const normalizedName = normalize(name);
+		const expected = normalize(`New ${name} Window`);
+		const matchesProfileWindow = (value) => {
+			const itemName = normalize(value);
+			return (
+				itemName === expected ||
+				(itemName.includes(normalizedName) && itemName.includes("window"))
+			);
+		};
+
+		const clickMatchInMenu = (menu) => {
+			const items = menu.menuItems();
+			for (let i = 0; i < items.length; i++) {
+				const item = items[i];
+				let itemName = "";
+				try {
+					itemName = item.name();
+				} catch (e) {}
+
+				if (matchesProfileWindow(itemName)) {
+					item.click();
+					return true;
+				}
+
+				try {
+					const submenus = item.menus();
+					for (let j = 0; j < submenus.length; j++) {
+						if (clickMatchInMenu(submenus[j])) {
+							return true;
+						}
+					}
+				} catch (e) {}
+			}
+			return false;
+		};
+
+		try {
+			const safariProcess = SystemEvents.processes.byName("Safari");
+			const fileMenu =
+				safariProcess.menuBars[0].menuBarItems.byName("File").menus[0];
+			return clickMatchInMenu(fileMenu);
+		} catch (e) {
+			return false;
+		}
+	};
+
+	const openInProfile = (p, name) => {
+		const beforeCount = Safari.windows.length;
+		// Use Safari's profile shortcut first.
 		SystemEvents.keystroke(p, {
 			using: ["option down", "shift down", "command down"],
 		});
-		delay(0.5); // Wait for the new window to appear
+		delay(0.8); // Wait for the new window to appear
+
+		if (Safari.windows.length > beforeCount) {
+			return true;
+		}
+
+		if (name && clickProfileMenuItem(name)) {
+			delay(0.8);
+			return Safari.windows.length > beforeCount;
+		}
+
+		return false;
 	};
 
 	const openStandardWindow = (u) => {
@@ -121,7 +190,13 @@ function run(argv) {
 	// Create the required number of windows.
 	for (let i = 0; i < windowsToCreate; i++) {
 		if (profile) {
-			openInProfile(profile);
+			if (!openInProfile(profile, profileName)) {
+				throw new Error(
+					`Could not open Safari profile ${profile}${
+						profileName ? ` (${profileName})` : ""
+					}. Check Alfred Accessibility permission and the Safari profile menu name.`
+				);
+			}
 		} else {
 			openStandardWindow(url);
 		}


### PR DESCRIPTION
### Problem
Selecting a Safari profile from `swp` passes the expected argument, such as `p5`, to `new_window.js`, but Safari may not open the profile window. Alfred Debugger reports `Processing complete`, so the failure is silent.

### Fix
- Wait briefly after activating Safari before sending the profile shortcut.
- Verify that a new Safari window was actually created.
- Fall back to clicking Safari's File menu profile window item by configured profile name.
- Throw a clear error if neither method opens a window.

### Tested
- Verified `src/new_window.js` compiles with `osacompile`.
- Verified locally in Alfred with Safari profile selection.